### PR TITLE
filter by branches

### DIFF
--- a/gitpushub-config.php.sample
+++ b/gitpushub-config.php.sample
@@ -26,4 +26,12 @@ $gitCommitsSplitLimit = 15;
 
 //- limit for patch size (bytes) in order to attach it
 $attachPatchSizeLimit = 4096;
+
+// branches
+// only: whitelist
+// except: blacklist
+// don't mix both
+$branches = array();
+$branches['only'] = array('master', '3.3', '4.0', '4.1', '4.2');
+//$branches['except'] = array();
 ?>

--- a/gitpushub.php
+++ b/gitpushub.php
@@ -33,6 +33,18 @@ function send_email_notification($jdoc)
 	if (0 === strpos($mbranch, 'refs/heads/')) {
 		$mbranch = substr($mbranch, 11);
 	}
+	if (array_key_exists('only', $branches)) {
+		if (!in_array($mbranch, $branches['only'])) {
+			error_log('branch: '. $mbranch. ' not in whitelist');
+			return;
+		}
+	}
+	elseif (array_key_exists('except', $branches)) {
+		if (in_array($mbranch, $branches['except'])) {
+			error_log('branch: '. $mbranch. ' in blacklist');
+			return;
+		}
+	}
 
 	if($nrcommits<=$gitCommitsSplitLimit) {
 		// one email per commit


### PR DESCRIPTION
- control the branches we want to send commit mail
- $branches['only'] is an array of whitelist branches.
- $branches['except'] is an array of blacklist branches.
- An empty $branches will mail all changes on all branches.
